### PR TITLE
Add a common base error

### DIFF
--- a/ilimit.c
+++ b/ilimit.c
@@ -33,6 +33,7 @@
 # include <pthread.h>
 #endif
 
+zend_class_entry *php_ilimit_ex;
 zend_class_entry *php_ilimit_sys_ex;
 zend_class_entry *php_ilimit_cpu_ex;
 zend_class_entry *php_ilimit_memory_ex;
@@ -75,22 +76,27 @@ PHP_MINIT_FUNCTION(ilimit)
 {
     zend_class_entry ce;
 
+    INIT_NS_CLASS_ENTRY(ce, "ilimit", "Error", NULL);
+
+    php_ilimit_ex =
+        zend_register_internal_class_ex(&ce, zend_ce_exception);
+
     INIT_NS_CLASS_ENTRY(ce, "ilimit", "Error\\System", NULL);
 
     php_ilimit_sys_ex =
-        zend_register_internal_class_ex(&ce, zend_ce_exception);
+        zend_register_internal_class_ex(&ce, php_ilimit_ex);
     php_ilimit_sys_ex->ce_flags |= ZEND_ACC_FINAL;
 
-    INIT_NS_CLASS_ENTRY(ce, "ilimit", "Error\\CPU", NULL);
+    INIT_NS_CLASS_ENTRY(ce, "ilimit", "Error\\Timeout", NULL);
 
     php_ilimit_cpu_ex =
-        zend_register_internal_class_ex(&ce, zend_ce_exception);
+        zend_register_internal_class_ex(&ce, php_ilimit_ex);
     php_ilimit_cpu_ex->ce_flags |= ZEND_ACC_FINAL;
 
     INIT_NS_CLASS_ENTRY(ce, "ilimit", "Error\\Memory", NULL);
 
     php_ilimit_memory_ex =
-        zend_register_internal_class_ex(&ce, zend_ce_exception);
+        zend_register_internal_class_ex(&ce, php_ilimit_ex);
     php_ilimit_memory_ex->ce_flags |= ZEND_ACC_FINAL;
 
     return SUCCESS;
@@ -349,7 +355,7 @@ static zend_always_inline void php_ilimit_call_destroy(php_ilimit_call_t *call) 
 
     if (call->state & PHP_ILIMIT_TIMEOUT) {
         zend_throw_exception_ex(php_ilimit_cpu_ex, 0,
-            "the cpu time limit of %" PRIu64 " microseconds has been reached",
+            "the time limit of %" PRIu64 " microseconds has been reached",
             call->limits.cpu);
     }
 

--- a/tests/001.phpt
+++ b/tests/001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Check ilimit cpu
+Check ilimit Timeout
 --SKIPIF--
 <?php
 if (!extension_loaded('ilimit')) {
@@ -13,7 +13,7 @@ if (!extension_loaded('ilimit')) {
 }, [], 1000000);
 ?>
 --EXPECTF--
-Fatal error: Uncaught ilimit\Error\CPU: the cpu time limit of 1000000 microseconds has been reached in %s/001.php:4
+Fatal error: Uncaught ilimit\Error\Timeout: the time limit of 1000000 microseconds has been reached in %s/001.php:4
 Stack trace:
 #0 %s/001.php(4): ilimit(Object(Closure), Array, 1000000)
 #1 {main}

--- a/tests/003.phpt
+++ b/tests/003.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Check ilimit catch cpu
+Check ilimit catch Timeout
 --SKIPIF--
 <?php
 if (!extension_loaded('ilimit')) {
@@ -12,7 +12,7 @@ try {
     \ilimit(function(){
         sleep(5);
     }, [], 1000000);
-} catch (\ilimit\Error\CPU $ex) {
+} catch (\ilimit\Error\Timeout $ex) {
     echo "OK\n";
 }
 ?>

--- a/tests/005.phpt
+++ b/tests/005.phpt
@@ -19,7 +19,7 @@ function wait() {
 \ilimit('wait', [], 1000000);
 ?>
 --EXPECTF--
-Fatal error: Uncaught ilimit\Error\CPU: the cpu time limit of 1000000 microseconds has been reached in %s/005.php:10
+Fatal error: Uncaught ilimit\Error\Timeout: the time limit of 1000000 microseconds has been reached in %s/005.php:10
 Stack trace:
 #0 %s/005.php(10): ilimit('wait', Array, 1000000)
 #1 {main}

--- a/tests/006.phpt
+++ b/tests/006.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Check ilimit cpu within while loops
+Check timeout within while loops
 --SKIPIF--
 <?php
 if (!extension_loaded('ilimit')) {
@@ -13,7 +13,7 @@ if (!extension_loaded('ilimit')) {
 }, [], 1000000);
 ?>
 --EXPECTF--
-Fatal error: Uncaught ilimit\Error\CPU: the cpu time limit of 1000000 microseconds has been reached in %s/006.php:4
+Fatal error: Uncaught ilimit\Error\Timeout: the time limit of 1000000 microseconds has been reached in %s/006.php:4
 Stack trace:
 #0 %s/006.php(4): ilimit(Object(Closure), Array, 1000000)
 #1 {main}

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -15,7 +15,7 @@ if (!extension_loaded('ilimit')) {
 }, [], 1000000);
 ?>
 --EXPECTF--
-Fatal error: Uncaught ilimit\Error\CPU: the cpu time limit of 500000 microseconds has been reached in %s/007.php:5
+Fatal error: Uncaught ilimit\Error\Timeout: the time limit of 500000 microseconds has been reached in %s/007.php:5
 Stack trace:
 #0 %s/007.php(5): ilimit(Object(Closure), Array, 500000)
 #1 [internal function]: {closure}()


### PR DESCRIPTION
This PR adds a common base error to make it easier to catch limit errors:

```php
try {
    \ilimit('sleep', 2, 10000, 10000);
} catch(\ilimit\Error\LimitReached $error) {
   // either System, CPU or Memory limit has been reached
}
```
