### PR TITLE
Add new tests

### DIFF
--- a/tests/017.phpt
+++ b/tests/017.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Check timeout with foreach
+--SKIPIF--
+<?php
+if (!extension_loaded('ilimit')) {
+	echo 'skip';
+}
+?>
+--FILE--
+<?php
+
+\ilimit\call(function () {
+	$generator = (function () : \Generator {
+		$i = 0;
+		while (true) {
+			yield $i++;
+		}
+	})();
+
+	foreach ($generator as $key => $value) {
+		continue;
+	}
+}, [], 9000);
+
+?>
+--EXPECT--
+Fatal error: Uncaught ilimit\Error\Timeout: the time limit of 9000 microseconds has been reached in %s:11
+Stack trace:
+#0 [internal function]: {closure}()
+#1 %s(14): ilimit\call(Object(Closure), Array, 9000)
+#2 {main}
+  thrown in %s on line 11

--- a/tests/018.phpt
+++ b/tests/018.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Check timeout with recursive functions
+--SKIPIF--
+<?php
+if (!extension_loaded('ilimit')) {
+	echo 'skip';
+}
+?>
+--FILE--
+<?php
+
+function fib(int $n) : int {
+	return ($n === 0 || $n === 1) ? $n : fib($n - 1) + fib($n - 2);
+}
+
+\ilimit\call('fib', [10 ** 6], 10 * 1000);
+
+?>
+--EXPECT--
+
+


### PR DESCRIPTION
The foreach-related segfault is intermittent, it only happens the timeout is reached at specific execution points:
![bug](https://s5.gifyu.com/images/ezgif-1-4dd8d7269d01.gif)